### PR TITLE
ResponseAssertions::assertHtmlResponseSnapshot() allows replacing values

### DIFF
--- a/src/MockeryTools/Http/ResponseAssertions.php
+++ b/src/MockeryTools/Http/ResponseAssertions.php
@@ -100,12 +100,16 @@ final class ResponseAssertions
     }
 
 
+    /**
+     * @param array<string, mixed> $valuesToReplace
+     */
     public static function assertHtmlResponseSnapshot(
         string $snapshotFile,
         ResponseInterface $response,
-        int $expectedStatusCode = self::STATUS_CODE_200
+        int $expectedStatusCode = self::STATUS_CODE_200,
+        array $valuesToReplace = []
     ): void {
-        SnapshotAssertions::assertResponseSnapshot($snapshotFile, $response);
+        SnapshotAssertions::assertResponseSnapshot($snapshotFile, $response, $valuesToReplace);
         self::assertResponseStatusCode($expectedStatusCode, $response);
     }
 

--- a/src/MockeryTools/Http/ResponseAssertions.php
+++ b/src/MockeryTools/Http/ResponseAssertions.php
@@ -101,7 +101,7 @@ final class ResponseAssertions
 
 
     /**
-     * @param array<string, mixed> $valuesToReplace
+     * @param array<string, string> $valuesToReplace
      */
     public static function assertHtmlResponseSnapshot(
         string $snapshotFile,

--- a/src/MockeryTools/Snapshot/SnapshotAssertions.php
+++ b/src/MockeryTools/Snapshot/SnapshotAssertions.php
@@ -46,8 +46,20 @@ final class SnapshotAssertions
     }
 
 
-    public static function assertResponseSnapshot(string $snapshotFile, ResponseInterface $response): void
-    {
+    /**
+     * @param array<string, string> $valuesToReplace
+     */
+    public static function assertResponseSnapshot(
+        string $snapshotFile, 
+        ResponseInterface $response,
+        array $valuesToReplace = []
+    ): void {
+        if ($valuesToReplace !== []) {
+            self::assertSnapshotAndReplace($snapshotFile, (string)$response->getBody(), $valuesToReplace);
+
+            return;
+        }
+
         self::assertSnapshot($snapshotFile, (string)$response->getBody());
     }
 }

--- a/src/MockeryTools/Snapshot/SnapshotAssertions.php
+++ b/src/MockeryTools/Snapshot/SnapshotAssertions.php
@@ -50,7 +50,7 @@ final class SnapshotAssertions
      * @param array<string, string> $valuesToReplace
      */
     public static function assertResponseSnapshot(
-        string $snapshotFile, 
+        string $snapshotFile,
         ResponseInterface $response,
         array $valuesToReplace = []
     ): void {


### PR DESCRIPTION
Allow passing an optional parameter for replacing variables in the snapshot before asserting in:
- `ResponseAssertions::assertHtmlResponseSnapshot()`
- `SnapshotAssertions::assertResponseSnapshot()`

This PR only makes usage of the library a bit easier, in a backward-compatible manner.

The usage of the optional parameter `$valuesToReplace` is similar to already existing methods `ResponseAssertions::assertJsonResponseEqualsJsonFile()` and  `ResponseAssertions::assertJsonResponseEqualsJsonString()`.

When the parameter is in use, the already existing `SnapshotAssertions::assertSnapshotAndReplace()` is used.