### PR TITLE
PseudoIntegrationTestCase: return Expectation where possible

### DIFF
--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -197,7 +197,14 @@ abstract class PseudoIntegrationTestCase extends TestCase
     ): Expectation {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
-        return $this->expectAuthorizedRequestFail($method, $url, $bearerToken, $errorCode, $responseBody, $requestOptions);
+        return $this->expectAuthorizedRequestFail(
+            $method,
+            $url,
+            $bearerToken,
+            $errorCode,
+            $responseBody,
+            $requestOptions,
+        );
     }
 
 
@@ -238,7 +245,14 @@ abstract class PseudoIntegrationTestCase extends TestCase
     ): Expectation {
         $url = $this->getPlatformApiHostDfo3() . $platformEndpoint;
 
-        return $this->expectAuthorizedRequestFail($method, $url, $bearerToken, $errorCode, $responseBody, $requestOptions);
+        return $this->expectAuthorizedRequestFail(
+            $method,
+            $url,
+            $bearerToken,
+            $errorCode,
+            $responseBody,
+            $requestOptions,
+        );
     }
 
 

--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Response as PsrResponse;
 use GuzzleHttp\RequestOptions;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\Expectation;
 use Mockery\MockInterface;
 use Nette\DI\Container;
 use Nette\Utils\Json;
@@ -114,10 +115,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $url,
         ?array $responseBody = null,
         ?array $requestOptions = null
-    ): void {
+    ): Expectation {
         $encodedResponseBody = $responseBody === null ? null : Json::encode($responseBody);
 
-        $this->expectRequestWithStringResponse($method, $url, $encodedResponseBody, $requestOptions);
+        return $this->expectRequestWithStringResponse($method, $url, $encodedResponseBody, $requestOptions);
     }
 
 
@@ -129,10 +130,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $url,
         ?string $responseBody = '',
         ?array $requestOptions = []
-    ): void {
+    ): Expectation {
         $psrResponse = new PsrResponse(200, [], $responseBody);
 
-        $this->httpClientMock->shouldReceive('request')
+        return $this->httpClientMock->shouldReceive('request')
             ->with($method, $url, $requestOptions ?? Mockery::any())
             ->once()
             ->andReturn($psrResponse);
@@ -149,8 +150,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $bearerToken,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
-        $this->expectRequest(
+    ): Expectation {
+        return $this->expectRequest(
             $method,
             $url,
             $responseBody,
@@ -169,10 +170,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $bearerToken,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
+    ): Expectation {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
-        $this->expectAuthorizedRequest(
+        return $this->expectAuthorizedRequest(
             $method,
             $url,
             $bearerToken,
@@ -193,10 +194,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         int $errorCode,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
+    ): Expectation {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
-        $this->expectAuthorizedRequestFail($method, $url, $bearerToken, $errorCode, $responseBody, $requestOptions);
+        return $this->expectAuthorizedRequestFail($method, $url, $bearerToken, $errorCode, $responseBody, $requestOptions);
     }
 
 
@@ -210,10 +211,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $bearerToken,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
+    ): Expectation {
         $url = $this->getPlatformApiHostDfo3() . $platformEndpoint;
 
-        $this->expectAuthorizedRequest(
+        return $this->expectAuthorizedRequest(
             $method,
             $url,
             $bearerToken,
@@ -234,10 +235,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         int $errorCode,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
+    ): Expectation {
         $url = $this->getPlatformApiHostDfo3() . $platformEndpoint;
 
-        $this->expectAuthorizedRequestFail($method, $url, $bearerToken, $errorCode, $responseBody, $requestOptions);
+        return $this->expectAuthorizedRequestFail($method, $url, $bearerToken, $errorCode, $responseBody, $requestOptions);
     }
 
 
@@ -251,10 +252,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $goldenKey,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
+    ): Expectation {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
-        $this->expectRequest(
+        return $this->expectRequest(
             $method,
             $url,
             $responseBody,
@@ -274,10 +275,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         int $errorCode = 400,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
+    ): Expectation {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
-        $this->expectRequestFail(
+        return $this->expectRequestFail(
             $method,
             $url,
             $errorCode,
@@ -297,8 +298,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
         int $errorCode = 400,
         ?string $responseBody = '',
         array $requestOptions = []
-    ): void {
-        $this->expectRequestWithStringResponseFail(
+    ): Expectation {
+        return $this->expectRequestWithStringResponseFail(
             $method,
             $url,
             $errorCode,
@@ -319,8 +320,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
         int $errorCode = 400,
         ?array $responseBody = null,
         array $requestOptions = []
-    ): void {
-        $this->expectRequestFail(
+    ): Expectation {
+        return $this->expectRequestFail(
             $method,
             $url,
             $errorCode,
@@ -340,10 +341,10 @@ abstract class PseudoIntegrationTestCase extends TestCase
         int $errorCode = 400,
         ?array $responseBody = null,
         ?array $requestOptions = []
-    ): void {
+    ): Expectation {
         $encodedResponseBody = $responseBody === null ? null : Json::encode($responseBody);
 
-        $this->expectRequestWithStringResponseFail(
+        return $this->expectRequestWithStringResponseFail(
             $method,
             $url,
             $errorCode,
@@ -362,12 +363,12 @@ abstract class PseudoIntegrationTestCase extends TestCase
         int $errorCode = 400,
         ?string $responseBody = '',
         ?array $requestOptions = []
-    ): void {
+    ): Expectation {
         $psrResponse = new PsrResponse($errorCode, [], $responseBody);
 
         $guzzleException = RequestException::create(new PsrRequest($method, $url), $psrResponse);
 
-        $this->httpClientMock->shouldReceive('request')
+        return $this->httpClientMock->shouldReceive('request')
             ->with($method, $url, $requestOptions ?? Mockery::any())
             ->once()
             ->andThrow($guzzleException);

--- a/src/MockeryTools/Snapshot/SnapshotAssertions.php
+++ b/src/MockeryTools/Snapshot/SnapshotAssertions.php
@@ -34,7 +34,7 @@ class SnapshotAssertions
     ): void {
         $snapshot = FileLoader::loadAsString($snapshotFile);
         $keys = array_map(
-            static fn (string $key): string => sprintf('{{%s}}', $key),
+            static fn(string $key): string => sprintf('{{%s}}', $key),
             array_keys($valuesToReplace),
         );
         $snapshotWithReplacedValues = str_replace(


### PR DESCRIPTION
Returning the `Expectation` objects allows for changing the expected number of calls via `->times(2)` or similar alterations of the expectation. Since previously there was no return value and there is little other to possibly return, I see no downsides.

Planning on releasing this as a MINOR version.