### PR TITLE
Return Expectation when expecting file content request

### DIFF
--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -442,6 +442,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
 
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     *
      * @param mixed[] $requestOptions
      *
      * @return Expectation
@@ -457,6 +459,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
 
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     *
      * @param mixed[] $requestOptions
      *
      * @return Expectation

--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -446,7 +446,7 @@ abstract class PseudoIntegrationTestCase extends TestCase
      *
      * @return Expectation
      */
-    protected function expectFileContentRequest(string $fileUrl, string $fileContent, string $contentType = '', ?array $requestOptions = []): void
+    protected function expectFileContentRequest(string $fileUrl, string $fileContent, string $contentType = '', ?array $requestOptions = [])
     {
         $psrResponse = new PsrResponse(200, ['Content-Type' => $contentType], $fileContent);
 
@@ -461,7 +461,7 @@ abstract class PseudoIntegrationTestCase extends TestCase
      *
      * @return Expectation
      */
-    protected function expectFileContentRequestFail(string $fileUrl, int $errorCode = 400, ?string $responseBody = '', ?array $requestOptions = []): void
+    protected function expectFileContentRequestFail(string $fileUrl, int $errorCode = 400, ?string $responseBody = '', ?array $requestOptions = [])
     {
         $psrResponse = new PsrResponse($errorCode, [], $responseBody);
 

--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -443,12 +443,14 @@ abstract class PseudoIntegrationTestCase extends TestCase
 
     /**
      * @param mixed[] $requestOptions
+     *
+     * @return Expectation
      */
     protected function expectFileContentRequest(string $fileUrl, string $fileContent, string $contentType = '', ?array $requestOptions = []): void
     {
         $psrResponse = new PsrResponse(200, ['Content-Type' => $contentType], $fileContent);
 
-        $this->httpClientMock->expects('request')
+        return $this->httpClientMock->expects('request')
             ->with('GET', $fileUrl, $requestOptions ?? Mockery::any())
             ->andReturn($psrResponse);
     }
@@ -456,6 +458,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
 
     /**
      * @param mixed[] $requestOptions
+     *
+     * @return Expectation
      */
     protected function expectFileContentRequestFail(string $fileUrl, int $errorCode = 400, ?string $responseBody = '', ?array $requestOptions = []): void
     {
@@ -463,7 +467,7 @@ abstract class PseudoIntegrationTestCase extends TestCase
 
         $guzzleException = RequestException::create(new PsrRequest('GET', $fileUrl), $psrResponse);
 
-        $this->httpClientMock->expects('request')
+        return $this->httpClientMock->expects('request')
             ->with('GET', $fileUrl, $requestOptions ?? Mockery::any())
             ->andThrow($guzzleException);
     }


### PR DESCRIPTION
Returns Expectation in new methods from #46, for example to allow calling `->twice()` on the returned object when using the method.