### PR TITLE
PseudoIntegrationTestCase: Compare arrays strictly when expecting requests

### DIFF
--- a/src/MockeryTools/Arrays/StrictArrayMatcher.php
+++ b/src/MockeryTools/Arrays/StrictArrayMatcher.php
@@ -38,7 +38,9 @@ class StrictArrayMatcher extends MatcherAbstract
             return false;
         }
 
-        return $this->sortArray($actual) === $this->sortedArray;
+        $actualSortedArray = $this->sortArray($actual);
+
+        return $actualSortedArray === $this->sortedArray;
     }
 
 

--- a/src/MockeryTools/Arrays/StrictArrayMatcher.php
+++ b/src/MockeryTools/Arrays/StrictArrayMatcher.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\MockeryTools\Arrays;
+
+use Mockery\Matcher\MatcherAbstract;
+use function is_array;
+use function ksort;
+use function print_r;
+use const PHP_EOL;
+
+class StrictArrayMatcher extends MatcherAbstract
+{
+    /**
+     * @var mixed[]
+     */
+    private array $sortedArray;
+
+
+    /**
+     * @param mixed[] $array
+     */
+    public function __construct(array $array)
+    {
+        parent::__construct();
+
+        $this->sortedArray = $this->sortArray($array);
+    }
+
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     *
+     * @param mixed $actual
+     */
+    public function match(&$actual): bool
+    {
+        if (!is_array($actual)) {
+            return false;
+        }
+
+        return $this->sortArray($actual) === $this->sortedArray;
+    }
+
+
+    /**
+     * @param mixed[] $array
+     *
+     * @return mixed[]
+     */
+    private function sortArray(array $array): array
+    {
+        ksort($array);
+        foreach ($array as &$item) {
+            if (is_array($item)) {
+                $item = $this->sortArray($item);
+            }
+        }
+
+        return $array;
+    }
+
+
+    public function __toString(): string
+    {
+        $output = '<ArrayMatch[Array: ' . PHP_EOL;
+
+        $output .= print_r($this->sortedArray, true);
+
+        return $output . ']>';
+    }
+}

--- a/src/MockeryTools/Arrays/StrictArrayMatcherTest.php
+++ b/src/MockeryTools/Arrays/StrictArrayMatcherTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\MockeryTools\Arrays;
+
+use Exception;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @final
+ */
+class StrictArrayMatcherTest extends TestCase
+{
+    /**
+     * @dataProvider arrayMatchesProvider
+     *
+     * @param mixed[] $expected
+     * @param mixed[] $actual
+     */
+    public function testMatches(array $expected, array $actual, bool $result): void
+    {
+        $matcher = new StrictArrayMatcher($expected);
+
+        Assert::assertSame($result, $matcher->match($actual));
+    }
+
+
+    /**
+     * @return mixed[][]
+     */
+    public function arrayMatchesProvider(): array
+    {
+        return [
+            'empty arrays match' => [
+                'expected' => [],
+                'actual' => [],
+                'result' => true,
+            ],
+            'same arrays match (int)' => [
+                'expected' => [1, 2, 3],
+                'actual' => [1, 2, 3],
+                'result' => true,
+            ],
+            'same arrays match (float)' => [
+                'expected' => [1.0, 2.0, 3.0],
+                'actual' => [1.0, 2.0, 3.0],
+                'result' => true,
+            ],
+            'same arrays match (string)' => [
+                'expected' => ['1', '2', '3'],
+                'actual' => ['1', '2', '3'],
+                'result' => true,
+            ],
+            'same arrays match (combined)' => [
+                'expected' => [1, 2.0, '3', [null, []]],
+                'actual' => [1, 2.0, '3', [null, []]],
+                'result' => true,
+            ],
+            'different types do not match (int/float)' => [
+                'expected' => [1, 2, 3],
+                'actual' => [1.0, 2.0, 3.0],
+                'result' => false,
+            ],
+            'different types do not match (int/string)' => [
+                'expected' => [1, 2, 3],
+                'actual' => ['1', '2', '3'],
+                'result' => false,
+            ],
+            'arrays in different order do not match' => [
+                'expected' => [1, 2, 3],
+                'actual' => [3, 2, 1],
+                'result' => false,
+            ],
+            'arrays in different order do not match even if multidimensional' => [
+                'expected' => [[[1, 2, 3]]],
+                'actual' => [[[3, 2, 1]]],
+                'result' => false,
+            ],
+            'associative arrays in different order match' => [
+                'expected' => ['first' => 1, 'second' => 2],
+                'actual' => ['second' => 2, 'first' => 1],
+                'result' => true,
+            ],
+            'associative arrays in different order match even if multidimensional' => [
+                'expected' => [[['first' => 1, 'second' => 2]]],
+                'actual' => [[['second' => 2, 'first' => 1]]],
+                'result' => true,
+            ],
+            'objects do not match if they are different instances' => [
+                'expected' => [new Exception()],
+                'actual' => [new Exception()],
+                'result' => false,
+            ],
+            'objects match if they are the same instance' => [
+                'expected' => [$exception = new Exception()],
+                'actual' => [$exception],
+                'result' => true,
+            ],
+        ];
+    }
+
+
+    public function testNoMatchIfNotArray(): void
+    {
+        $matcher = new StrictArrayMatcher([]);
+
+        $actual = null;
+
+        Assert::assertFalse($matcher->match($actual));
+    }
+}

--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -2,6 +2,7 @@
 
 namespace BrandEmbassy\MockeryTools\PseudoIntegration;
 
+use BrandEmbassy\MockeryTools\Arrays\StrictArrayMatcher;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request as PsrRequest;
@@ -133,7 +134,7 @@ abstract class PseudoIntegrationTestCase extends TestCase
         $psrResponse = new PsrResponse(200, [], $responseBody);
 
         $this->httpClientMock->shouldReceive('request')
-            ->with($method, $url, $requestOptions ?? Mockery::any())
+            ->with($method, $url, $this->convertRequestOptionsToArgumentMatcher($requestOptions))
             ->once()
             ->andReturn($psrResponse);
     }
@@ -368,7 +369,7 @@ abstract class PseudoIntegrationTestCase extends TestCase
         $guzzleException = RequestException::create(new PsrRequest($method, $url), $psrResponse);
 
         $this->httpClientMock->shouldReceive('request')
-            ->with($method, $url, $requestOptions ?? Mockery::any())
+            ->with($method, $url, $this->convertRequestOptionsToArgumentMatcher($requestOptions))
             ->once()
             ->andThrow($guzzleException);
     }
@@ -380,6 +381,19 @@ abstract class PseudoIntegrationTestCase extends TestCase
     protected function getServiceMocks(): array
     {
         return [];
+    }
+
+
+    /**
+     * @return mixed
+     */
+    protected function convertRequestOptionsToArgumentMatcher(?array $requestOptions)
+    {
+        if ($requestOptions === null) {
+            return Mockery::any();
+        }
+
+        return new StrictArrayMatcher($requestOptions);
     }
 
 

--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -488,6 +488,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
 
 
     /**
+     * @param mixed[]|null $requestOptions
+     *
      * @return mixed
      */
     protected function convertRequestOptionsToArgumentMatcher(?array $requestOptions)

--- a/src/MockeryTools/Snapshot/SnapshotAssertions.php
+++ b/src/MockeryTools/Snapshot/SnapshotAssertions.php
@@ -34,7 +34,7 @@ class SnapshotAssertions
     ): void {
         $snapshot = FileLoader::loadAsString($snapshotFile);
         $keys = array_map(
-            static fn (string $key): string => sprintf('{{%s}}', $key),
+            static fn(string $key): string => sprintf('{{%s}}', $key),
             array_keys($valuesToReplace),
         );
         $snapshotWithReplacedValues = str_replace(


### PR DESCRIPTION
`PseudoIntegrationTestCase` now compares provided request options more strictly (i.e. using `===` after sorting both arrays). Choice of matcher was extracted into protected `PseudoIntegrationTestCase::convertRequestOptionsToArgumentMatcher()` method so it can be reverted or changed in a specific test / group of tests.

Because of the possibility of revert and the importance of strict comparisons in tests, I suggest releasing this as a MINOR version.

This PR was suggested to avoid hard-to-debug issues such as https://github.com/BrandEmbassy/channel-integrations/pull/1539