### PR TITLE
DE-44861 Fix `PseudoIntegrationTestCase::setUp` method visibility

### DIFF
--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -35,7 +35,7 @@ abstract class PseudoIntegrationTestCase extends TestCase
     protected $httpClientMock;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = $this->createContainer();
         $this->replacedServices = $this->loadMockServices();


### PR DESCRIPTION
`PseudoIntegrationTestCase::setUp` method has wrong visibility. It should be protected as in the parent class.