### PR TITLE
DE-40274 Allow marc-mabe/php-enum ^3.0 || ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "guzzlehttp/guzzle": "^6.3 || ^7.0",
-    "marc-mabe/php-enum": "^3.0",
+    "marc-mabe/php-enum": "^3.0 || ^4.0",
     "mockery/mockery": "^1.3",
     "nette/di": "^2.4 || ^3.0",
     "nette/utils": "^2.4 || ^3.0",


### PR DESCRIPTION
marc-mabe/php-enum ^4.x has more support for php 8.1