### PR TITLE
DE-79149 Replace usage of Guzzles Request Option JSON for BODY

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "ext-mbstring": "*",
     "guzzlehttp/guzzle": "^6.3 || ^7.0",
     "marc-mabe/php-enum": "^3.0 || ^4.0",
-    "mockery/mockery": "^1.3",
+    "mockery/mockery": "^1.6.7",
     "nette/di": "^2.4 || ^3.0",
     "nette/utils": "^2.4 || ^3.0",
     "phpunit/phpunit": ">=8.5.23 || ^9.0",

--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -485,7 +485,7 @@ abstract class PseudoIntegrationTestCase extends TestCase
      */
     protected function expectFileContentRequestFail(
         string $fileUrl,
-        int $errorCode = 400,
+        int $errorCode,
         ?string $responseBody = '',
         ?array $requestOptions = null
     ) {

--- a/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
+++ b/src/MockeryTools/PseudoIntegration/PseudoIntegrationTestCase.php
@@ -2,21 +2,24 @@
 
 namespace BrandEmbassy\MockeryTools\PseudoIntegration;
 
-use BrandEmbassy\MockeryTools\Arrays\StrictArrayMatcher;
+use BrandEmbassy\MockeryTools\RequestOptionsMatcher\RequestOptionsMatcher;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request as PsrRequest;
 use GuzzleHttp\Psr7\Response as PsrResponse;
-use GuzzleHttp\RequestOptions;
+use LogicException;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\Expectation;
+use Mockery\Matcher\MatcherInterface;
 use Mockery\MockInterface;
 use Nette\DI\Container;
 use Nette\Utils\Json;
 use PHPUnit\Framework\TestCase;
+use function get_class;
 use function implode;
 use function md5;
+use function sprintf;
 
 abstract class PseudoIntegrationTestCase extends TestCase
 {
@@ -108,42 +111,63 @@ abstract class PseudoIntegrationTestCase extends TestCase
 
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     *
-     * @param mixed[] $responseBody
-     * @param mixed[]|null $requestOptions
-     *
-     * @return Expectation
+     * @param array<string, string> $headersToAdd
      */
-    protected function expectRequest(
-        string $method,
-        string $url,
-        ?array $responseBody = null,
-        ?array $requestOptions = null
-    ) {
-        $encodedResponseBody = $responseBody === null ? null : Json::encode($responseBody);
+    private function addHeadersToMatcher(MatcherInterface $requestOptionsMatcher, array $headersToAdd): MatcherInterface
+    {
+        if ($requestOptionsMatcher instanceof RequestOptionsMatcher) {
+            $matcher = $requestOptionsMatcher;
+            foreach ($headersToAdd as $headerName => $headerValue) {
+                $matcher = $requestOptionsMatcher->withHeader($headerName, $headerValue);
+            }
 
-        return $this->expectRequestWithStringResponse($method, $url, $encodedResponseBody, $requestOptions);
+            return $matcher;
+        }
+
+        throw new LogicException(
+            sprintf(
+                'Cannot add header to matcher of type %s. Use method which does not manipulate with headers or use %s instead',
+                get_class($requestOptionsMatcher),
+                RequestOptionsMatcher::class,
+            ),
+        );
     }
 
 
     /**
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
-     * @param mixed[]|null $requestOptions
+     * @param mixed[] $responseBody
+     *
+     * @return Expectation
+     */
+    protected function expectRequest(
+        string $method,
+        string $url,
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
+    ) {
+        $encodedResponseBody = $responseBody === null ? null : Json::encode($responseBody);
+
+        return $this->expectRequestWithStringResponse($method, $url, $requestOptionsMatcher, $encodedResponseBody);
+    }
+
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @return Expectation
      */
     protected function expectRequestWithStringResponse(
         string $method,
         string $url,
-        ?string $responseBody = '',
-        ?array $requestOptions = []
+        MatcherInterface $requestOptionsMatcher,
+        ?string $responseBody = ''
     ) {
         $psrResponse = new PsrResponse(200, [], $responseBody);
 
         return $this->httpClientMock->shouldReceive('request')
-            ->with($method, $url, $this->convertRequestOptionsToArgumentMatcher($requestOptions))
+            ->with($method, $url, $requestOptionsMatcher)
             ->once()
             ->andReturn($psrResponse);
     }
@@ -153,7 +177,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -161,14 +184,16 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $method,
         string $url,
         string $bearerToken,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
+        $matcher = $this->addHeadersToMatcher($requestOptionsMatcher, ['Authorization' => 'Bearer ' . $bearerToken]);
+
         return $this->expectRequest(
             $method,
             $url,
+            $matcher,
             $responseBody,
-            $requestOptions + [RequestOptions::HEADERS => ['Authorization' => 'Bearer ' . $bearerToken]],
         );
     }
 
@@ -177,7 +202,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -185,8 +209,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $method,
         string $platformEndpoint,
         string $bearerToken,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
@@ -194,8 +218,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
             $method,
             $url,
             $bearerToken,
+            $requestOptionsMatcher,
             $responseBody,
-            $requestOptions,
         );
     }
 
@@ -204,7 +228,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -213,8 +236,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $platformEndpoint,
         string $bearerToken,
         int $errorCode,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
@@ -223,8 +246,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
             $url,
             $bearerToken,
             $errorCode,
+            $requestOptionsMatcher,
             $responseBody,
-            $requestOptions,
         );
     }
 
@@ -233,7 +256,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -241,8 +263,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $method,
         string $platformEndpoint,
         string $bearerToken,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         $url = $this->getPlatformApiHostDfo3() . $platformEndpoint;
 
@@ -250,8 +272,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
             $method,
             $url,
             $bearerToken,
+            $requestOptionsMatcher,
             $responseBody,
-            $requestOptions,
         );
     }
 
@@ -260,7 +282,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -269,8 +290,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $platformEndpoint,
         string $bearerToken,
         int $errorCode,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         $url = $this->getPlatformApiHostDfo3() . $platformEndpoint;
 
@@ -279,8 +300,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
             $url,
             $bearerToken,
             $errorCode,
+            $requestOptionsMatcher,
             $responseBody,
-            $requestOptions,
         );
     }
 
@@ -289,7 +310,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -297,16 +317,16 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $method,
         string $platformEndpoint,
         string $goldenKey,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
         return $this->expectRequest(
             $method,
             $url,
+            $this->addHeadersToMatcher($requestOptionsMatcher, ['X-Api-Token' => $goldenKey]),
             $responseBody,
-            $requestOptions + [RequestOptions::HEADERS => ['X-Api-Token' => $goldenKey]],
         );
     }
 
@@ -315,7 +335,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -323,9 +342,9 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $method,
         string $platformEndpoint,
         string $goldenKey,
-        int $errorCode = 400,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        int $errorCode,
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         $url = $this->getPlatformApiHost() . $platformEndpoint;
 
@@ -333,16 +352,14 @@ abstract class PseudoIntegrationTestCase extends TestCase
             $method,
             $url,
             $errorCode,
+            $this->addHeadersToMatcher($requestOptionsMatcher, ['X-Api-Token' => $goldenKey]),
             $responseBody,
-            $requestOptions + [RequestOptions::HEADERS => ['X-Api-Token' => $goldenKey]],
         );
     }
 
 
     /**
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     *
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -350,16 +367,16 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $method,
         string $url,
         string $bearerToken,
-        int $errorCode = 400,
-        ?string $responseBody = '',
-        array $requestOptions = []
+        int $errorCode,
+        MatcherInterface $requestOptionsMatcher,
+        ?string $responseBody = ''
     ) {
         return $this->expectRequestWithStringResponseFail(
             $method,
             $url,
             $errorCode,
+            $this->addHeadersToMatcher($requestOptionsMatcher, ['Authorization' => 'Bearer ' . $bearerToken]),
             $responseBody,
-            $requestOptions + [RequestOptions::HEADERS => ['Authorization' => 'Bearer ' . $bearerToken]],
         );
     }
 
@@ -368,7 +385,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
@@ -376,16 +392,16 @@ abstract class PseudoIntegrationTestCase extends TestCase
         string $method,
         string $url,
         string $bearerToken,
-        int $errorCode = 400,
-        ?array $responseBody = null,
-        array $requestOptions = []
+        int $errorCode,
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         return $this->expectRequestFail(
             $method,
             $url,
             $errorCode,
+            $this->addHeadersToMatcher($requestOptionsMatcher, ['Authorization' => 'Bearer ' . $bearerToken]),
             $responseBody,
-            $requestOptions + [RequestOptions::HEADERS => ['Authorization' => 'Bearer ' . $bearerToken]],
         );
     }
 
@@ -394,16 +410,15 @@ abstract class PseudoIntegrationTestCase extends TestCase
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
      * @param mixed[] $responseBody
-     * @param mixed[] $requestOptions
      *
      * @return Expectation
      */
     protected function expectRequestFail(
         string $method,
         string $url,
-        int $errorCode = 400,
-        ?array $responseBody = null,
-        ?array $requestOptions = []
+        int $errorCode,
+        MatcherInterface $requestOptionsMatcher,
+        ?array $responseBody = null
     ) {
         $encodedResponseBody = $responseBody === null ? null : Json::encode($responseBody);
 
@@ -411,8 +426,8 @@ abstract class PseudoIntegrationTestCase extends TestCase
             $method,
             $url,
             $errorCode,
+            $requestOptionsMatcher,
             $encodedResponseBody,
-            $requestOptions,
         );
     }
 
@@ -420,23 +435,21 @@ abstract class PseudoIntegrationTestCase extends TestCase
     /**
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
      *
-     * @param mixed[] $requestOptions
-     *
      * @return Expectation
      */
     protected function expectRequestWithStringResponseFail(
         string $method,
         string $url,
-        int $errorCode = 400,
-        ?string $responseBody = '',
-        ?array $requestOptions = []
+        int $errorCode,
+        MatcherInterface $requestOptionsMatcher,
+        ?string $responseBody = ''
     ) {
         $psrResponse = new PsrResponse($errorCode, [], $responseBody);
 
         $guzzleException = RequestException::create(new PsrRequest($method, $url), $psrResponse);
 
         return $this->httpClientMock->shouldReceive('request')
-            ->with($method, $url, $this->convertRequestOptionsToArgumentMatcher($requestOptions))
+            ->with($method, $url, $requestOptionsMatcher)
             ->once()
             ->andThrow($guzzleException);
     }
@@ -449,8 +462,12 @@ abstract class PseudoIntegrationTestCase extends TestCase
      *
      * @return Expectation
      */
-    protected function expectFileContentRequest(string $fileUrl, string $fileContent, string $contentType = '', ?array $requestOptions = null)
-    {
+    protected function expectFileContentRequest(
+        string $fileUrl,
+        string $fileContent,
+        string $contentType = '',
+        ?array $requestOptions = null
+    ) {
         $psrResponse = new PsrResponse(200, ['Content-Type' => $contentType], $fileContent);
 
         return $this->httpClientMock->expects('request')
@@ -466,8 +483,12 @@ abstract class PseudoIntegrationTestCase extends TestCase
      *
      * @return Expectation
      */
-    protected function expectFileContentRequestFail(string $fileUrl, int $errorCode = 400, ?string $responseBody = '', ?array $requestOptions = null)
-    {
+    protected function expectFileContentRequestFail(
+        string $fileUrl,
+        int $errorCode = 400,
+        ?string $responseBody = '',
+        ?array $requestOptions = null
+    ) {
         $psrResponse = new PsrResponse($errorCode, [], $responseBody);
 
         $guzzleException = RequestException::create(new PsrRequest('GET', $fileUrl), $psrResponse);
@@ -484,21 +505,6 @@ abstract class PseudoIntegrationTestCase extends TestCase
     protected function getServiceMocks(): array
     {
         return [];
-    }
-
-
-    /**
-     * @param mixed[]|null $requestOptions
-     *
-     * @return mixed
-     */
-    protected function convertRequestOptionsToArgumentMatcher(?array $requestOptions)
-    {
-        if ($requestOptions === null) {
-            return Mockery::any();
-        }
-
-        return new StrictArrayMatcher($requestOptions);
     }
 
 

--- a/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
+++ b/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
@@ -31,11 +31,11 @@ class RequestOptionsMatcher implements MatcherInterface
 
 
     /**
-     * @param mixed[] $bodyToEncode
+     * @param mixed[] $body
      */
-    public static function createForRequestWithBodyToEncode(array $bodyToEncode): self
+    public static function createWithBody(array $body): self
     {
-        $jsonEncodedBody = self::sortAndEncodeBody($bodyToEncode);
+        $jsonEncodedBody = self::sortAndEncodeBody($body);
 
         return new self([
             RequestOptions::BODY => $jsonEncodedBody,
@@ -47,12 +47,12 @@ class RequestOptionsMatcher implements MatcherInterface
 
 
     /**
-     * @param mixed[] $bodyToEncode
+     * @param mixed[] $body
      * @param array<string, string> $headers
      */
-    public static function createForRequestWithBodyToEncodeAndHeaders(array $bodyToEncode, array $headers): self
+    public static function createWithBodyAndHeaders(array $body, array $headers): self
     {
-        $jsonEncodedBody = self::sortAndEncodeBody($bodyToEncode);
+        $jsonEncodedBody = self::sortAndEncodeBody($body);
 
         return new self([
             RequestOptions::BODY => $jsonEncodedBody,
@@ -61,7 +61,7 @@ class RequestOptionsMatcher implements MatcherInterface
     }
 
 
-    public static function createForRequestWithBody(string $body): self
+    public static function createWithStringBody(string $body): self
     {
         return new self([RequestOptions::BODY => $body]);
     }
@@ -70,7 +70,7 @@ class RequestOptionsMatcher implements MatcherInterface
     /**
      * @param array<string, string> $headers
      */
-    public static function createForRequestWithBodyAndHeaders(string $body, array $headers): self
+    public static function createWithStringBodyAndHeaders(string $body, array $headers): self
     {
         return new self([
             RequestOptions::BODY => $body,
@@ -80,28 +80,28 @@ class RequestOptionsMatcher implements MatcherInterface
 
 
     /**
-     * @param mixed[] $body
+     * @param mixed[] $jsonBody
      */
-    public static function createForRequestWithJsonBody(array $body): self
+    public static function createWithJsonBody(array $jsonBody): self
     {
-        return new self([RequestOptions::JSON => $body]);
+        return new self([RequestOptions::JSON => $jsonBody]);
     }
 
 
     /**
-     * @param mixed[] $body
+     * @param mixed[] $jsonBody
      * @param array<string, string> $headers
      */
-    public static function createForRequestWithJsonBodyAndHeaders(array $body, array $headers): self
+    public static function createWithJsonBodyAndHeaders(array $jsonBody, array $headers): self
     {
         return new self([
-            RequestOptions::JSON => $body,
+            RequestOptions::JSON => $jsonBody,
             RequestOptions::HEADERS => $headers,
         ]);
     }
 
 
-    public static function createForRequestWithEmptyBody(): self
+    public static function createWithEmptyBody(): self
     {
         return new self([]);
     }
@@ -110,7 +110,7 @@ class RequestOptionsMatcher implements MatcherInterface
     /**
      * @param array<string, string> $headers
      */
-    public static function createForRequestWithEmptyBodyAndHeaders(array $headers): self
+    public static function createWithEmptyBodyAndHeaders(array $headers): self
     {
         return new self([RequestOptions::HEADERS => $headers]);
     }
@@ -119,7 +119,7 @@ class RequestOptionsMatcher implements MatcherInterface
     /**
      * @param mixed[] $requestOptions
      */
-    public static function createForRequestOptions(array $requestOptions): self
+    public static function create(array $requestOptions): self
     {
         return new self($requestOptions);
     }
@@ -127,8 +127,11 @@ class RequestOptionsMatcher implements MatcherInterface
 
     /**
      * @param mixed[] $requestOptions
+     *
+     * @internal Do not use in your tests, intended for usage in Channels PseudoIntegration test class only.
+     * This method keeps deprecated methods working until they are removed
      */
-    public static function createForRequestOptionsWithConversionFromJsonToBodyOption(array $requestOptions): self
+    public static function createWithConversionFromJsonToBodyOption(array $requestOptions): self
     {
         if (isset($requestOptions[RequestOptions::JSON])) {
             $requestOptions[RequestOptions::BODY] = self::sortAndEncodeBody($requestOptions[RequestOptions::JSON]);

--- a/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
+++ b/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
@@ -141,6 +141,8 @@ class RequestOptionsMatcher implements MatcherInterface
 
 
     /**
+     * @deprecated
+     *
      * @param mixed[] $requestOptions
      *
      * @internal Do not use in your tests, intended for usage in Channels PseudoIntegration test class only.

--- a/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
+++ b/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
@@ -1,0 +1,229 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\MockeryTools\RequestOptionsMatcher;
+
+use GuzzleHttp\RequestOptions;
+use Mockery\Matcher\MatcherInterface;
+use Nette\Utils\Json;
+use Nette\Utils\JsonException;
+use function is_array;
+use function is_string;
+use function ksort;
+
+class RequestOptionsMatcher implements MatcherInterface
+{
+    /**
+     * @var mixed[]
+     */
+    private array $sortedExpectedRequestOptions;
+
+
+    /**
+     * @param mixed[] $requestOptions
+     */
+    private function __construct(array $requestOptions)
+    {
+        if (isset($requestOptions[RequestOptions::BODY]) && is_string($requestOptions[RequestOptions::BODY])) {
+            $requestOptions[RequestOptions::BODY] = $this->getSortedBody($requestOptions[RequestOptions::BODY]);
+        }
+        $this->sortedExpectedRequestOptions = self::sortRequestOptions($requestOptions);
+    }
+
+
+    /**
+     * @param mixed[] $bodyToEncode
+     */
+    public static function createForRequestWithBodyToEncode(array $bodyToEncode): self
+    {
+        $jsonEncodedBody = self::sortAndEncodeBody($bodyToEncode);
+
+        return new self([
+            RequestOptions::BODY => $jsonEncodedBody,
+            RequestOptions::HEADERS => [
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+    }
+
+
+    /**
+     * @param mixed[] $bodyToEncode
+     * @param array<string, string> $headers
+     */
+    public static function createForRequestWithBodyToEncodeAndHeaders(array $bodyToEncode, array $headers): self
+    {
+        $jsonEncodedBody = self::sortAndEncodeBody($bodyToEncode);
+
+        return new self([
+            RequestOptions::BODY => $jsonEncodedBody,
+            RequestOptions::HEADERS => $headers + ['Content-Type' => 'application/json'],
+        ]);
+    }
+
+
+    public static function createForRequestWithBody(string $body): self
+    {
+        return new self([RequestOptions::BODY => $body]);
+    }
+
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public static function createForRequestWithBodyAndHeaders(string $body, array $headers): self
+    {
+        return new self([
+            RequestOptions::BODY => $body,
+            RequestOptions::HEADERS => $headers,
+        ]);
+    }
+
+
+    /**
+     * @param mixed[] $body
+     */
+    public static function createForRequestWithJsonBody(array $body): self
+    {
+        return new self([RequestOptions::JSON => $body]);
+    }
+
+
+    /**
+     * @param mixed[] $body
+     * @param array<string, string> $headers
+     */
+    public static function createForRequestWithJsonBodyAndHeaders(array $body, array $headers): self
+    {
+        return new self([
+            RequestOptions::JSON => $body,
+            RequestOptions::HEADERS => $headers,
+        ]);
+    }
+
+
+    public static function createForRequestWithEmptyBody(): self
+    {
+        return new self([]);
+    }
+
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public static function createForRequestWithEmptyBodyAndHeaders(array $headers): self
+    {
+        return new self([RequestOptions::HEADERS => $headers]);
+    }
+
+
+    /**
+     * @param mixed[] $requestOptions
+     */
+    public static function createForRequestOptions(array $requestOptions): self
+    {
+        return new self($requestOptions);
+    }
+
+
+    /**
+     * @param mixed[] $requestOptions
+     */
+    public static function createForRequestOptionsWithConversionFromJsonToBodyOption(array $requestOptions): self
+    {
+        if (isset($requestOptions[RequestOptions::JSON])) {
+            $requestOptions[RequestOptions::BODY] = self::sortAndEncodeBody($requestOptions[RequestOptions::JSON]);
+            $requestOptions[RequestOptions::HEADERS]['Content-Type'] = 'application/json';
+
+            unset($requestOptions[RequestOptions::JSON]);
+        }
+
+        return new self($requestOptions);
+    }
+
+
+    /**
+     * @param mixed[] $body
+     */
+    private static function sortAndEncodeBody(array $body): string
+    {
+        return Json::encode(self::sortRequestOptions($body));
+    }
+
+
+    public function withHeader(string $headerName, string $headerValue): self
+    {
+        $this->sortedExpectedRequestOptions[RequestOptions::HEADERS][$headerName] = $headerValue;
+
+        return new self($this->sortedExpectedRequestOptions);
+    }
+
+
+    /**
+     * @param mixed $optionValue
+     */
+    public function withRequestOption(string $optionName, $optionValue): self
+    {
+        $this->sortedExpectedRequestOptions[$optionName] = $optionValue;
+
+        return new self($this->sortedExpectedRequestOptions);
+    }
+
+
+    /**
+     * @param mixed $actual
+     */
+    public function match(&$actual): bool
+    {
+        if (!is_array($actual)) {
+            return false;
+        }
+
+        if (isset($actual[RequestOptions::BODY]) && is_string($actual[RequestOptions::BODY])) {
+            $actual[RequestOptions::BODY] = $this->getSortedBody($actual[RequestOptions::BODY]);
+        }
+
+        $actualSortedRequestOptions = self::sortRequestOptions($actual);
+
+        return $actualSortedRequestOptions === $this->sortedExpectedRequestOptions;
+    }
+
+
+    private function getSortedBody(string $body): string
+    {
+        try {
+            $decodedBody = Json::decode($body, Json::FORCE_ARRAY);
+
+            if (!is_array($decodedBody)) {
+                return $body;
+            }
+
+            return Json::encode(self::sortRequestOptions($decodedBody));
+        } catch (JsonException $exception) {
+            return $body;
+        }
+    }
+
+
+    /**
+     * @param mixed[] $array
+     *
+     * @return mixed[]
+     */
+    private static function sortRequestOptions(array $array): array
+    {
+        ksort($array);
+        foreach ($array as &$item) {
+            if (is_array($item)) {
+                $item = self::sortRequestOptions($item);
+            }
+        }
+
+        return $array;
+    }
+
+
+    public function __toString()
+    {
+        return '<RequestOptionsMatcher>';
+    }
+}

--- a/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
+++ b/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcher.php
@@ -31,6 +31,9 @@ class RequestOptionsMatcher implements MatcherInterface
 
 
     /**
+     * Provided $body will be JSON encoded and added as RequestOption::BODY.
+     * Content-Type: application/json header is added
+     *
      * @param mixed[] $body
      */
     public static function createWithBody(array $body): self
@@ -47,6 +50,9 @@ class RequestOptionsMatcher implements MatcherInterface
 
 
     /**
+     * Provided $body will be JSON encoded and added as RequestOption::BODY.
+     * Content-Type: application/json header is added besided headers provided
+     *
      * @param mixed[] $body
      * @param array<string, string> $headers
      */
@@ -61,25 +67,32 @@ class RequestOptionsMatcher implements MatcherInterface
     }
 
 
-    public static function createWithStringBody(string $body): self
+    /**
+     * Provided $stringBody will be set as RequestOption::BODY.
+     */
+    public static function createWithStringBody(string $stringBody): self
     {
-        return new self([RequestOptions::BODY => $body]);
+        return new self([RequestOptions::BODY => $stringBody]);
     }
 
 
     /**
+     * Provided $stringBody will be set as RequestOption::BODY.
+     *
      * @param array<string, string> $headers
      */
-    public static function createWithStringBodyAndHeaders(string $body, array $headers): self
+    public static function createWithStringBodyAndHeaders(string $stringBody, array $headers): self
     {
         return new self([
-            RequestOptions::BODY => $body,
+            RequestOptions::BODY => $stringBody,
             RequestOptions::HEADERS => $headers,
         ]);
     }
 
 
     /**
+     * Provided $jsonBody will be set as RequestOption::JSON.
+     *
      * @param mixed[] $jsonBody
      */
     public static function createWithJsonBody(array $jsonBody): self
@@ -89,6 +102,8 @@ class RequestOptionsMatcher implements MatcherInterface
 
 
     /**
+     * Provided $jsonBody will be set as RequestOption::JSON.
+     *
      * @param mixed[] $jsonBody
      * @param array<string, string> $headers
      */

--- a/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcherTest.php
+++ b/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcherTest.php
@@ -8,9 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 class RequestOptionsMatcherTest extends TestCase
 {
-    public function testCreateForRequestWithBodyToEncode(): void
+    public function testCreateWithBody(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithBodyToEncode(
+        $matcher = RequestOptionsMatcher::createWithBody(
             [
                 'dataToEncode' => 123,
                 'moreData' => '456',
@@ -28,9 +28,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestWithBodyToEncodeAndHeaders(): void
+    public function testCreateWithBodyAndHeaders(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithBodyToEncodeAndHeaders(
+        $matcher = RequestOptionsMatcher::createWithBodyAndHeaders(
             [
                 'dataToEncode' => 123,
                 'moreData' => '456',
@@ -47,9 +47,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestWithBody(): void
+    public function testCreateWithStringBody(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithBody('{"dataToEncode":123,"moreData":"456"}');
+        $matcher = RequestOptionsMatcher::createWithStringBody('{"dataToEncode":123,"moreData":"456"}');
 
         $matchingData = [
             RequestOptions::BODY => '{"dataToEncode":123,"moreData":"456"}',
@@ -58,9 +58,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestWithBodyAndHeaders(): void
+    public function testCreateWithStringBodyAndHeaders(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithBodyAndHeaders(
+        $matcher = RequestOptionsMatcher::createWithStringBodyAndHeaders(
             '{"dataToEncode":123,"moreData":"456"}',
             ['Accept' => 'application/json'],
         );
@@ -73,9 +73,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestWithJsonBody(): void
+    public function testCreateWithJsonBody(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithJsonBody(
+        $matcher = RequestOptionsMatcher::createWithJsonBody(
             [
                 'dataToEncode' => 1.23,
                 'moreData' => '456',
@@ -92,9 +92,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestWithJsonBodyAndHeaders(): void
+    public function testCreateWithJsonBodyAndHeaders(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithJsonBodyAndHeaders(
+        $matcher = RequestOptionsMatcher::createWithJsonBodyAndHeaders(
             [
                 'dataToEncode' => 1.23,
                 'moreData' => '456',
@@ -113,9 +113,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestWithEmptyBody(): void
+    public function testCreateWithEmptyBody(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBody();
+        $matcher = RequestOptionsMatcher::createWithEmptyBody();
 
         $matchingData = [];
 
@@ -123,9 +123,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestWithEmptyBodyAndHeaders(): void
+    public function testCreateWithEmptyBodyAndHeaders(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBodyAndHeaders(['Accept' => 'application/json']);
+        $matcher = RequestOptionsMatcher::createWithEmptyBodyAndHeaders(['Accept' => 'application/json']);
 
         $matchingData = [
             RequestOptions::HEADERS => ['Accept' => 'application/json'],
@@ -135,9 +135,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestOptions(): void
+    public function testCreate(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestOptions(
+        $matcher = RequestOptionsMatcher::create(
             [
                 RequestOptions::CERT => 'cert',
                 RequestOptions::BODY => '2',
@@ -153,9 +153,9 @@ class RequestOptionsMatcherTest extends TestCase
     }
 
 
-    public function testCreateForRequestOptionsWithConversionFromJsonToBodyOption(): void
+    public function testCreateWithConversionFromJsonToBodyOption(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestOptionsWithConversionFromJsonToBodyOption([
+        $matcher = RequestOptionsMatcher::createWithConversionFromJsonToBodyOption([
             RequestOptions::JSON => [
                 'dataToEncode' => 1.23,
                 'moreData' => '456',
@@ -173,7 +173,7 @@ class RequestOptionsMatcherTest extends TestCase
 
     public function testExpectedDataIsReordered(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestOptions([
+        $matcher = RequestOptionsMatcher::create([
             RequestOptions::HEADERS => [],
             RequestOptions::JSON => [
                 'z' => 'z',
@@ -196,7 +196,7 @@ class RequestOptionsMatcherTest extends TestCase
 
     public function testActualDataIsReordered(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestOptions([
+        $matcher = RequestOptionsMatcher::create([
             RequestOptions::BODY => '{"dataToEncode":1.23,"moreData":"456"}',
             RequestOptions::JSON => [
                 'a' => 'a',
@@ -219,7 +219,7 @@ class RequestOptionsMatcherTest extends TestCase
 
     public function testWithHeader(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBody()->withHeader('Accept', 'application/json');
+        $matcher = RequestOptionsMatcher::createWithEmptyBody()->withHeader('Accept', 'application/json');
 
         $matchingData = [
             RequestOptions::HEADERS => ['Accept' => 'application/json'],
@@ -230,7 +230,7 @@ class RequestOptionsMatcherTest extends TestCase
 
     public function testWithRequestOption(): void
     {
-        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBody()->withRequestOption(RequestOptions::CERT, 'cert');
+        $matcher = RequestOptionsMatcher::createWithEmptyBody()->withRequestOption(RequestOptions::CERT, 'cert');
 
         $matchingData = [
             RequestOptions::CERT => 'cert',

--- a/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcherTest.php
+++ b/src/MockeryTools/RequestOptionsMatcher/RequestOptionsMatcherTest.php
@@ -1,0 +1,240 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\MockeryTools\RequestOptionsMatcher;
+
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class RequestOptionsMatcherTest extends TestCase
+{
+    public function testCreateForRequestWithBodyToEncode(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithBodyToEncode(
+            [
+                'dataToEncode' => 123,
+                'moreData' => '456',
+            ],
+        );
+
+        $matchingData = [
+            RequestOptions::BODY => '{"dataToEncode":123,"moreData":"456"}',
+            RequestOptions::HEADERS => [
+                'Content-Type' => 'application/json',
+            ],
+        ];
+
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestWithBodyToEncodeAndHeaders(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithBodyToEncodeAndHeaders(
+            [
+                'dataToEncode' => 123,
+                'moreData' => '456',
+            ],
+            ['Accept' => 'application/json'],
+        );
+
+        $matchingData = [
+            RequestOptions::BODY => '{"dataToEncode":123,"moreData":"456"}',
+            RequestOptions::HEADERS => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
+        ];
+
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestWithBody(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithBody('{"dataToEncode":123,"moreData":"456"}');
+
+        $matchingData = [
+            RequestOptions::BODY => '{"dataToEncode":123,"moreData":"456"}',
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestWithBodyAndHeaders(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithBodyAndHeaders(
+            '{"dataToEncode":123,"moreData":"456"}',
+            ['Accept' => 'application/json'],
+        );
+
+        $matchingData = [
+            RequestOptions::BODY => '{"dataToEncode":123,"moreData":"456"}',
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestWithJsonBody(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithJsonBody(
+            [
+                'dataToEncode' => 1.23,
+                'moreData' => '456',
+            ],
+        );
+
+        $matchingData = [
+            RequestOptions::JSON => [
+                'dataToEncode' => 1.23,
+                'moreData' => '456',
+            ],
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestWithJsonBodyAndHeaders(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithJsonBodyAndHeaders(
+            [
+                'dataToEncode' => 1.23,
+                'moreData' => '456',
+            ],
+            ['Accept' => 'application/json'],
+        );
+
+        $matchingData = [
+            RequestOptions::JSON => [
+                'dataToEncode' => 1.23,
+                'moreData' => '456',
+            ],
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestWithEmptyBody(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBody();
+
+        $matchingData = [];
+
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestWithEmptyBodyAndHeaders(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBodyAndHeaders(['Accept' => 'application/json']);
+
+        $matchingData = [
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+        ];
+
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestOptions(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestOptions(
+            [
+                RequestOptions::CERT => 'cert',
+                RequestOptions::BODY => '2',
+            ],
+        );
+
+        $matchingData = [
+            RequestOptions::CERT => 'cert',
+            RequestOptions::BODY => '2',
+        ];
+
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testCreateForRequestOptionsWithConversionFromJsonToBodyOption(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestOptionsWithConversionFromJsonToBodyOption([
+            RequestOptions::JSON => [
+                'dataToEncode' => 1.23,
+                'moreData' => '456',
+            ],
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+        ]);
+
+        $matchingData = [
+            RequestOptions::BODY => '{"dataToEncode":1.23,"moreData":"456"}',
+            RequestOptions::HEADERS => ['Accept' => 'application/json', 'Content-Type' => 'application/json'],
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testExpectedDataIsReordered(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestOptions([
+            RequestOptions::HEADERS => [],
+            RequestOptions::JSON => [
+                'z' => 'z',
+                'a' => 'a',
+            ],
+            RequestOptions::BODY => '{"moreData":"456","dataToEncode":1.23}',
+        ]);
+
+        $matchingData = [
+            RequestOptions::BODY => '{"dataToEncode":1.23,"moreData":"456"}',
+            RequestOptions::JSON => [
+                'a' => 'a',
+                'z' => 'z',
+            ],
+            RequestOptions::HEADERS => [],
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testActualDataIsReordered(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestOptions([
+            RequestOptions::BODY => '{"dataToEncode":1.23,"moreData":"456"}',
+            RequestOptions::JSON => [
+                'a' => 'a',
+                'z' => 'z',
+            ],
+            RequestOptions::HEADERS => [],
+        ]);
+
+        $matchingData = [
+            RequestOptions::HEADERS => [],
+            RequestOptions::JSON => [
+                'z' => 'z',
+                'a' => 'a',
+            ],
+            RequestOptions::BODY => '{"moreData":"456","dataToEncode":1.23}',
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testWithHeader(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBody()->withHeader('Accept', 'application/json');
+
+        $matchingData = [
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+
+
+    public function testWithRequestOption(): void
+    {
+        $matcher = RequestOptionsMatcher::createForRequestWithEmptyBody()->withRequestOption(RequestOptions::CERT, 'cert');
+
+        $matchingData = [
+            RequestOptions::CERT => 'cert',
+        ];
+        Assert::assertTrue($matcher->match($matchingData));
+    }
+}


### PR DESCRIPTION
Description: Guzzle option JSON does not allow control of how is the json data encoded. Using option BODY and encoding the data ourselves allows us to ensure correct encoding is done
Impact: BC break of tests