### PR TITLE
DE-107348 Remove authorized methods 

### DIFF
--- a/src/MockeryTools/Enum/EnumValueMatcher.php
+++ b/src/MockeryTools/Enum/EnumValueMatcher.php
@@ -3,14 +3,23 @@
 namespace BrandEmbassy\MockeryTools\Enum;
 
 use MabeEnum\Enum;
-use Mockery\Matcher\MatcherAbstract;
+use Mockery\Matcher\MatcherInterface;
 use function assert;
 
 /**
  * @final
  */
-class EnumValueMatcher extends MatcherAbstract
+class EnumValueMatcher implements MatcherInterface
 {
+    protected mixed $expected;
+
+
+    public function __construct(mixed $expected = null)
+    {
+        $this->expected = $expected;
+    }
+
+
     /**
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
@@ -21,12 +30,12 @@ class EnumValueMatcher extends MatcherAbstract
     {
         assert($actual instanceof Enum);
 
-        return $actual->getValue() === $this->_expected;
+        return $actual->getValue() === $this->expected;
     }
 
 
     public function __toString(): string
     {
-        return '<EnumValue:' . $this->_expected . '>';
+        return '<EnumValue:' . $this->expected . '>';
     }
 }

--- a/src/MockeryTools/String/UuidMatcher.php
+++ b/src/MockeryTools/String/UuidMatcher.php
@@ -2,18 +2,21 @@
 
 namespace BrandEmbassy\MockeryTools\String;
 
-use Mockery\Matcher\MatcherAbstract;
+use Mockery\Matcher\MatcherInterface;
 use Ramsey\Uuid\UuidInterface;
 use function assert;
 
 /**
  * @final
  */
-class UuidMatcher extends MatcherAbstract
+class UuidMatcher implements MatcherInterface
 {
+    private string $expected;
+
+
     public function __construct(string $expected)
     {
-        parent::__construct($expected);
+        $this->expected = $expected;
     }
 
 
@@ -27,12 +30,12 @@ class UuidMatcher extends MatcherAbstract
     {
         assert($actual instanceof UuidInterface);
 
-        return $actual->toString() === $this->_expected;
+        return $actual->toString() === $this->expected;
     }
 
 
     public function __toString(): string
     {
-        return '<Uuid:' . $this->_expected . '>';
+        return '<Uuid:' . $this->expected . '>';
     }
 }


### PR DESCRIPTION
Currently there were two methods to set Authorization header when using expectAuthorized methods: through parameter and explicitly in headers. This PR removes option to set bearer tokens through parameter to clear up usage.