### PR TITLE
DE-103741 add ability to send request options with request

### DIFF
--- a/src/MockeryTools/Http/HttpClientMockBuilder.php
+++ b/src/MockeryTools/Http/HttpClientMockBuilder.php
@@ -133,6 +133,7 @@ class HttpClientMockBuilder
     /**
      * @param array<string, mixed> $responseDataToReturn
      * @param array<string, mixed> $expectedRequestData
+     * @param array<string, mixed> $options
      *
      * @throws JsonException
      */
@@ -141,15 +142,22 @@ class HttpClientMockBuilder
         string $expectedEndpoint,
         array $responseDataToReturn = [],
         ?array $expectedRequestData = null,
-        int $statusCodeToReturn = 200
+        int $statusCodeToReturn = 200,
+        ?array $options = null,
     ): self {
         $responseBody = Json::encode($responseDataToReturn);
         $expectedRequestBody = $expectedRequestData !== null ? Json::encode($expectedRequestData) : '';
         $requestMatcher = $this->createRequestMatcher($expectedHttpMethod, $expectedEndpoint, $expectedRequestBody);
 
-        $this->httpClientMock->expects('send')
-            ->with($requestMatcher)
-            ->andReturn(new Response($statusCodeToReturn, [], $responseBody));
+        if ($options !== null) {
+            $this->httpClientMock->expects('send')
+                ->with($requestMatcher, $options)
+                ->andReturn(new Response($statusCodeToReturn, [], $responseBody));
+        } else {
+            $this->httpClientMock->expects('send')
+                ->with($requestMatcher)
+                ->andReturn(new Response($statusCodeToReturn, [], $responseBody));
+        }
 
         return $this;
     }

--- a/src/MockeryTools/Http/HttpClientMockBuilderTest.php
+++ b/src/MockeryTools/Http/HttpClientMockBuilderTest.php
@@ -24,6 +24,7 @@ class HttpClientMockBuilderTest extends TestCase
 
     private const BASE_PATH = 'https://api.com/v2';
     private const HEADERS = ['Authorization' => 'Bearer thisIsSomeToken'];
+    private const OPTIONS = ['testOption', 'testValue'];
 
 
     /**
@@ -196,7 +197,7 @@ class HttpClientMockBuilderTest extends TestCase
                 'GET',
                 '/users/25',
                 ['name' => 'Prokop Buben'],
-                options: [],
+                options: self::OPTIONS,
             )
             ->build();
 
@@ -205,7 +206,7 @@ class HttpClientMockBuilderTest extends TestCase
             new Uri('https://api.com/v2/users/25'),
             self::HEADERS,
         );
-        $response = $httpClientMock->send($request, []);
+        $response = $httpClientMock->send($request, self::OPTIONS);
 
         Assert::assertSame('{"name":"Prokop Buben"}', (string)$response->getBody());
     }

--- a/src/MockeryTools/Http/HttpClientMockBuilderTest.php
+++ b/src/MockeryTools/Http/HttpClientMockBuilderTest.php
@@ -189,6 +189,31 @@ class HttpClientMockBuilderTest extends TestCase
     /**
      * @throws Throwable
      */
+    public function testSendGetWithOptions(): void
+    {
+        $httpClientMock = HttpClientMockBuilder::create(self::BASE_PATH, self::HEADERS)
+            ->expectSend(
+                'GET',
+                '/users/25',
+                ['name' => 'Prokop Buben'],
+                options: [],
+            )
+            ->build();
+
+        $request = new Request(
+            'GET',
+            new Uri('https://api.com/v2/users/25'),
+            self::HEADERS,
+        );
+        $response = $httpClientMock->send($request, []);
+
+        Assert::assertSame('{"name":"Prokop Buben"}', (string)$response->getBody());
+    }
+
+
+    /**
+     * @throws Throwable
+     */
     public function testSendPostWithSuccess(): void
     {
         $httpClientMock = HttpClientMockBuilder::create(self::BASE_PATH, self::HEADERS)

--- a/src/MockeryTools/Http/HttpClientMockBuilderTest.php
+++ b/src/MockeryTools/Http/HttpClientMockBuilderTest.php
@@ -24,7 +24,7 @@ class HttpClientMockBuilderTest extends TestCase
 
     private const BASE_PATH = 'https://api.com/v2';
     private const HEADERS = ['Authorization' => 'Bearer thisIsSomeToken'];
-    private const OPTIONS = ['testOption', 'testValue'];
+    private const OPTIONS = ['testOption' => 'testValue'];
 
 
     /**


### PR DESCRIPTION
Adds the ability to mock the request so that you can pass it the $options parameter as well. This was implemented in a way that it is backwards compatible, so only if it is needed do you need to pass it.